### PR TITLE
Convert jmeter to service

### DIFF
--- a/ansible/fhir-stress-test.yml
+++ b/ansible/fhir-stress-test.yml
@@ -73,6 +73,8 @@
       service:
         name: bluebutton-jmeter
         state: started
+      async: 30
+      poll: 0
       become: true
 
   tasks:

--- a/ansible/fhir-stress-test.yml
+++ b/ansible/fhir-stress-test.yml
@@ -59,16 +59,38 @@
   become: True
   environment: "{{proxy_env}}"
   gather_facts: True
-  
+  handlers:
+    - name: Reload Services
+      command: /usr/bin/systemctl daemon-reload
+      become: true
+
+    - name: Start JMeter Service
+      service:
+        name: bluebutton-jmeter
+        state: started
+      become: true
+
   tasks:
-    - name: Launch JMeter Server in Background
-      # The "JMeter Server" is what the distributed testing nodes run.
-      shell: "nohup {{ remote_jmeter_dir }}/bin/jmeter -s 
-        -Djava.rmi.server.hostname={{ ansible_eth0.ipv4.address }}
-        -Dserver.rmi.localport={{ jmeter_server_rmi_local_port }} 
-        -Dserver_port={{ jmeter_server_port }} 
-        -j {{ remote_test_dir }}/log-jmeter.txt
-        &> {{ remote_test_dir }}/log-jmeter-console.txt &" 
+    - name: Create JMeter Service Wrapper Script
+      template:
+        src: bluebutton-jmeter.sh.j2
+        dest: "{{ remote_test_dir }}/bluebutton-jmeter.sh"
+        owner: "{{ remote_jmeter_user }}"
+        group: "{{ remote_jmeter_user }}"
+        mode: u=rwx,g=rx,o=rx
+      become: true
+
+    - name: Create JMeter Service Definition
+      template:
+        src: bluebutton-jmeter.service.j2
+        dest: /etc/systemd/system/bluebutton-jmeter.service
+        owner: "{{ remote_jmeter_user }}"
+        group: "{{ remote_jmeter_user }}"
+        mode: u=rw,g=r,o=r
+      become: true
+      notify:
+        - 'Reload Services'
+        - 'Start JMeter Service'
 
 - name: Launch JMeter client and start tests
   hosts: client

--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -11,11 +11,11 @@ test_plan: "../jmeter-project/jmeter-fhir-test.jmx"
 # location of local keystore used in test
 test_keystore: "../dev/ssl-stores/client.keystore"
 # remote directory to store jmeter test
-remote_test_dir: "/opt/fhir_stress"
+remote_test_dir: "/usr/local/bluebutton-jmeter-service"
 # location of local jmeter properties file overrides
 jmeter_properties_file: "../jmeter-project/jmeter.properties"
 # jmeter version
-jmeter_version: 4.0
+jmeter_version: 5.0
 # remote location of apache jmeter installation
 remote_jmeter_dir: "{{ remote_test_dir }}/apache-jmeter-{{ jmeter_version }}"
 # remote jmeter server port 
@@ -26,6 +26,9 @@ jmeter_server_rmi_local_port: 4000
 jmeter_client_rmi_local_port: 4001
 # URI of FHIR server under test
 fhir_server: "https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir"
+# remote user to run jmeter
+remote_jmeter_user: bb-jmeter
+
 
 # NOTE: As configured, a sampler thread will run until the time duration has elapsed, the thread_loop count is ignored because continue_forever is set to true.
 # Number of threads within the JMeter Thread Group (https://jmeter.apache.org/api/org/apache/jmeter/threads/AbstractThreadGroup.html#NUM_THREADS)
@@ -37,6 +40,7 @@ thread_loops: 1000
 # Enables the duration field for the sampler threads.  
 scheduler: true
 # The duration in seconds for a sampler thread to run.
+# The duration is used to set the async timeout duration (even if scheduler is false) 
 duration: 300
 # Poll interval(in seconds) to check for test completion.  Used because some servers will disconnect the ssh connection prior to test completion causing the ansible script to fail,
 poll: 30
@@ -61,11 +65,11 @@ env_tag: TEST
 # https://aws.amazon.com/marketplace/pp/B019NS7T5I
 ami_id_rhel: ami-2051294a
 
-##
-# TODO: These are specific to the GDIT dev playground AWS account
-subnet_id: subnet-b9a6e492
+###
+# TODO: These are specific to the GDIT BB AWS account
+subnet_id: subnet-43851a1f
 
 security_group_ids:
-  - sg-fbc4b59c
-  - sg-0215d9e116b23f489
-##
+  - sg-c254c582
+  - sg-00934127d109774ad
+###

--- a/ansible/roles/client/tasks/main.yml
+++ b/ansible/roles/client/tasks/main.yml
@@ -4,7 +4,7 @@
   copy: 
     src: "{{ test_plan }}"
     dest: "{{ remote_test_dir }}"
-    owner: root
-    group: root
+    owner: "{{ remote_jmeter_user }}"
+    group: "{{ remote_jmeter_user }}"
     mode: 0664
   

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -9,10 +9,19 @@
     - java-1.8.0-openjdk-devel
   become: true
 
+- name: Create JMeter Service User
+  user:
+    name: "{{ remote_jmeter_user }}"
+    shell: /bin/false
+  become: true
+
 - name: Create Directory Tree for '{{ remote_test_dir }}' 
   file: 
     path: "{{ remote_test_dir }}" 
     state: directory
+    owner: "{{ remote_jmeter_user }}"
+    group: "{{ remote_jmeter_user }}"
+    mode: u=rwx,g=rx,o=rx
 
 - name: Copy and Unpack JMeter
   unarchive: 
@@ -22,8 +31,8 @@
 - name: Fix JMeter Executable Permissions
   file: 
     path: "{{ item }}"
-    owner: root
-    group: root
+    owner: "{{ remote_jmeter_user }}"
+    group: "{{ remote_jmeter_user }}"
     mode: 0774
   with_items:
     - "{{ remote_jmeter_dir }}/bin/jmeter-server"
@@ -33,6 +42,6 @@
   copy: 
     src: "{{ jmeter_properties_file }}"
     dest: "{{ remote_jmeter_dir }}/bin"
-    owner: root
-    group: root
+    owner: "{{ remote_jmeter_user }}"
+    group: "{{ remote_jmeter_user }}"
     mode: 0644

--- a/ansible/roles/server/tasks/main.yml
+++ b/ansible/roles/server/tasks/main.yml
@@ -4,8 +4,8 @@
   copy: 
     src: "{{ test_lib }}"
     dest: "{{ remote_jmeter_dir }}/lib/ext/"
-    owner: root
-    group: root
+    owner: "{{ remote_jmeter_user }}"
+    group: "{{ remote_jmeter_user }}"
     mode: 0664
 
 - name: Create Keystore Directory 
@@ -17,6 +17,6 @@
   copy: 
     src: "{{ test_keystore }}"
     dest: "{{ remote_test_dir }}/dev/ssl-stores"
-    owner: root
-    group: root
+    owner: "{{ remote_jmeter_user }}"
+    group: "{{ remote_jmeter_user }}"
     mode: 0664

--- a/ansible/templates/bluebutton-jmeter.service.j2
+++ b/ansible/templates/bluebutton-jmeter.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Blue Button JMeter Service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory={{ remote_test_dir }}
+ExecStart={{ remote_test_dir }}/bluebutton-jmeter.sh
+User={{ remote_jmeter_user }}
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/bluebutton-jmeter.service.j2
+++ b/ansible/templates/bluebutton-jmeter.service.j2
@@ -7,7 +7,6 @@ Type=oneshot
 WorkingDirectory={{ remote_test_dir }}
 ExecStart={{ remote_test_dir }}/bluebutton-jmeter.sh
 User={{ remote_jmeter_user }}
-RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/templates/bluebutton-jmeter.sh.j2
+++ b/ansible/templates/bluebutton-jmeter.sh.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+{{ remote_jmeter_dir }}/bin/jmeter -s \
+-Djava.rmi.server.hostname={{ ansible_eth0.ipv4.address }} \
+-Dserver.rmi.localport={{ jmeter_server_rmi_local_port }} \
+-Dserver_port={{ jmeter_server_port }} \
+-j {{ remote_test_dir }}/log-jmeter.txt \
+&> {{ remote_test_dir }}/log-jmeter-console.txt &

--- a/ansible/templates/bluebutton-jmeter.sh.j2
+++ b/ansible/templates/bluebutton-jmeter.sh.j2
@@ -5,4 +5,4 @@
 -Dserver.rmi.localport={{ jmeter_server_rmi_local_port }} \
 -Dserver_port={{ jmeter_server_port }} \
 -j {{ remote_test_dir }}/log-jmeter.txt \
-&> {{ remote_test_dir }}/log-jmeter-console.txt &
+&> {{ remote_test_dir }}/log-jmeter-console.txt

--- a/jmeter-project/jmeter-fhir-test.jmx
+++ b/jmeter-project/jmeter-fhir-test.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="4.0" jmeter="4.0 r1823414">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.0 r1840935">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="FHIR Stress Test" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -14,7 +14,7 @@
           </elementProp>
           <elementProp name="keystore_dir" elementType="Argument">
             <stringProp name="Argument.name">keystore_dir</stringProp>
-            <stringProp name="Argument.value">${__P(keystore_dir,/opt/fhir_stress/dev/ssl-stores)}</stringProp>
+            <stringProp name="Argument.value">${__P(keystore_dir,/usr/local/bluebutton-jmeter-service/dev/ssl-stores)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="proxy_host" elementType="Argument">
@@ -39,7 +39,7 @@
           </elementProp>
           <elementProp name="thread_count" elementType="Argument">
             <stringProp name="Argument.name">thread_count</stringProp>
-            <stringProp name="Argument.value">${__P(thread_count,5)}</stringProp>
+            <stringProp name="Argument.value">${__P(thread_count,10)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="continue_forever" elementType="Argument">
@@ -200,7 +200,7 @@
       <TestFragmentController guiclass="TestFragmentControllerGui" testclass="TestFragmentController" testname="WorkBench Test Fragment" enabled="false"/>
       <hashTree>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
-          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <boolProp name="ResultCollector.error_logging">true</boolProp>
           <objProp>
             <name>saveConfig</name>
             <value class="SampleSaveConfiguration">
@@ -227,12 +227,13 @@
               <assertionsResultsToSave>0</assertionsResultsToSave>
               <bytes>true</bytes>
               <sentBytes>true</sentBytes>
+              <url>true</url>
               <threadCounts>true</threadCounts>
               <idleTime>true</idleTime>
               <connectTime>true</connectTime>
             </value>
           </objProp>
-          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-14\10-23\log.jtl</stringProp>
+          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-12-12\08-04\log.jtl</stringProp>
         </ResultCollector>
         <hashTree/>
         <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
@@ -268,7 +269,7 @@
               <connectTime>true</connectTime>
             </value>
           </objProp>
-          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-14\10-23\log.jtl</stringProp>
+          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-28\12-46\log.jtl</stringProp>
         </ResultCollector>
         <hashTree/>
         <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
@@ -304,7 +305,7 @@
               <connectTime>true</connectTime>
             </value>
           </objProp>
-          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-14\10-23\log.jtl</stringProp>
+          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-28\15-15\log.jtl</stringProp>
         </ResultCollector>
         <hashTree/>
         <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
@@ -340,7 +341,7 @@
               <connectTime>true</connectTime>
             </value>
           </objProp>
-          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-14\10-23\log.jtl</stringProp>
+          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-28\15-15\log.jtl</stringProp>
         </ResultCollector>
         <hashTree/>
         <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="true">
@@ -371,12 +372,13 @@
               <assertionsResultsToSave>0</assertionsResultsToSave>
               <bytes>true</bytes>
               <sentBytes>true</sentBytes>
+              <url>true</url>
               <threadCounts>true</threadCounts>
               <idleTime>true</idleTime>
               <connectTime>true</connectTime>
             </value>
           </objProp>
-          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-14\10-23\log.jtl</stringProp>
+          <stringProp name="filename">C:\bit9prog\dev\projects\bluebutton-data-server-perf-tests\ansible\results\2018-11-28\15-15\log.jtl</stringProp>
         </ResultCollector>
         <hashTree/>
       </hashTree>

--- a/src/main/java/gov/hhs/cms/bluebutton/fhirstress/backend/CustomSamplerClient.java
+++ b/src/main/java/gov/hhs/cms/bluebutton/fhirstress/backend/CustomSamplerClient.java
@@ -55,7 +55,7 @@ public abstract class CustomSamplerClient extends AbstractJavaSamplerClient {
 	public Arguments getDefaultParameters() {
 		Arguments defaultParameters = new Arguments();
 		defaultParameters.addArgument(PARAM_SERVER, "https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir");
-		defaultParameters.addArgument(KEYSTORE_DIR, "/opt/fhir_stress/dev/ssl-stores");
+		defaultParameters.addArgument(KEYSTORE_DIR, "/usr/local/bluebutton-jmeter-service/dev/ssl-stores");
 		defaultParameters.addArgument(PROXY_HOST, "null");
 		defaultParameters.addArgument(PROXY_PORT, "0");
 		defaultParameters.addArgument(RIFFILE, "beneficiary_test.rif");


### PR DESCRIPTION
This PR refactors a bunch of the test to start the jmeter test as service running as a new user instead of root.
Also changed the AWS account this runs against.

BLUEBUTTON-619